### PR TITLE
Repair generate mw4530r firmware default is 8M (#3732)

### DIFF
--- a/target/linux/ar71xx/image/generic-tp-link.mk
+++ b/target/linux/ar71xx/image/generic-tp-link.mk
@@ -366,13 +366,6 @@ $(Device/tplink-8mlzma)
 endef
 TARGET_DEVICES += tl-wdr6500-v6
 
-define Device/mw4530r-v1
-  $(Device/tl-wdr4300-v1)
-  DEVICE_TITLE := Mercury MW4530R v1
-  TPLINK_HWID := 0x45300001
-endef
-TARGET_DEVICES += mw4530r-v1
-
 define Device/tl-wpa8630-v1
   $(Device/tplink-8mlzma)
   DEVICE_TITLE := TP-LINK TL-WPA8630 v1

--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -889,8 +889,8 @@ endef
 TARGET_DEVICES += mc-mac1200r
 
 define Device/mc-mw4530r
-$(Device/tplink-16mlzma)
-  DEVICE_TITLE := MerCury MW4530R
+$(Device/tplink-8mlzma)
+  DEVICE_TITLE := Mercury MW4530R
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   BOARDNAME := MC-MW4530R
   DEVICE_PROFILE := MW4530R


### PR DESCRIPTION
* ath79: add support for TP-Link TL-WR882N/WR885N/WR886N

This adds support for the various clones of the TL-WR885N recently
supported  ("ath79: add support for TP-Link TL-WR885N v1"):

- tplink,tl-wr882n-v1
- tplink,tl-wr882n-v2
- tplink,tl-wr882n-v3
- tplink,tl-wr885n-v1
- tplink,tl-wr885n-v2
- tplink,tl-wr886n-v2
- tplink,tl-wr886n-v3
- tplink,tl-wr886n-v4
- tplink,tl-wr886n-v5
- tplink,tl-wr886n-v6
- tplink,tl-wr886n-v7

These devices are cloned in ar71xx. All models added in this patch are the same hardware CPU

WR885n V2 was tested.

Specifications:
- SOC: Qualcomm Atheros TP9343-AL3A
- CPU: 750MHz
- Flash: 2 MiB (AH1446 25Q16BS1G E5N102)
- RAM: 16 MiB (Zentel A3S28D40JTP-50)
- WLAN: Qualcomm Atheros TP9343 450Mbps
- Ethernet: Atheros AR8228/AR8229  4 port (100M)

添加TP9343芯片的路由器型号支持，TL-WR882N/WR885N/WR886N系列

* ath79: add support for MerCury MW4530R v1

重新添加水星MW4530R路由器支持

* Repair generate mw4530r firmware default is 8M

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
